### PR TITLE
Installation and Docs fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 TOGETHER_API_KEY=your-together-api-key-here
 GEMINI_API_KEY=your-gemini-api-key-here
 DEEPSEEK_API_KEY=your-deepseek-api-key-here
+OPENROUTER_API_KEY=your-openrouter-api-key-here

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,33 @@
+name: Build test for CAIS package
+  
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+  repository_dispatch:
+    types: [create-pull-request]
+  workflow_dispatch:
+  
+jobs:  
+  test:
+    name: build test for cais package
+    runs-on: ubuntu-latest  
+    strategy:  
+      matrix:  
+        python-version: ["3.10"]  
+  
+    steps:  
+      - uses: actions/checkout@v3  
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies  
+        run: |  
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install cais package
+        run: |
+          pip install -e .
+          python -c "import cais; print(cais.__version__)"

--- a/README.md
+++ b/README.md
@@ -87,9 +87,12 @@ cp .env.example .env
 Open `.env` and set the API keys for the provider(s) you intend to use:
 
 ```
-OPENAI_API_KEY=your_openai_key_here
-ANTHROPIC_API_KEY=your_anthropic_key_here
-TOGETHER_API_KEY=your_together_key_here
+OPENAI_API_KEY=sk-your-openai-api-key-here
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+TOGETHER_API_KEY=your-together-api-key-here
+GEMINI_API_KEY=your-gemini-api-key-here
+DEEPSEEK_API_KEY=your-deepseek-api-key-here
+OPENROUTER_API_KEY=your-openrouter-api-key-here
 ```
 
 Only the key corresponding to your chosen `--llm_provider` is required.
@@ -118,7 +121,7 @@ pip install -e .
 The CauSciBench benchmark dataset is hosted on [HuggingFace](https://huggingface.co/datasets/causal-nlp/causcibench). To download it:
 
 ```bash
-python experiments/download_data.py
+python experiments/data/download_data.py
 ```
 
 This will populate `experiments/data/causcibench/` with the following structure:
@@ -155,7 +158,7 @@ python experiments/scripts/run_cais.py \
 | `--output_dir` | `str` | Path to the folder where output JSON results will be saved |
 | `--output_name` | `str` | Name of the output JSON file |
 | `--llm_name` | `str` | Name of the LLM to use (e.g., `gpt-4o`, `claude-3-5-sonnet`) |
-| `--llm_provider` | `str` | LLM service provider (e.g., `openai`, `anthropic`, `together`) |
+| `--llm_provider` | `str` | LLM service provider (e.g., `openai`, `anthropic`, `together`, `openrouter`) |
 | `--iv_llm` | `bool` | *(Optional)* If present, enables the advanced experimental [IV-LLM pipeline](https://arxiv.org/abs/2602.07943) for instrument discovery. |
 
 **Example:**

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -170,6 +170,7 @@ sparse==0.17.0
 Sphinx==8.1.3
 sphinx-autodoc-typehints==3.0.1
 sphinx-rtd-theme==3.0.2
+sphinx-sitemap==2.9.0
 sphinx_design==0.6.1
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,10 +46,10 @@ Jinja2==3.1.6
 jiter==0.9.0
 joblib==1.4.2
 jsonpatch==1.33
-dowhy
+dowhy<=0.11.1
 matplotlib==3.10.1
 langchain==0.3.26
 rddensity
 rdd
-litellm
+litellm==1.80.0 # In future, please switch directly to >=v1.83.0 to avoid Supply Chain Incident in LiteLLM package (refer to https://docs.litellm.ai/blog/security-update-march-2026)
 langchain-litellm


### PR DESCRIPTION
This PR fixes the following:
1. causal-agent package installation error:
     pip._vendor.pkg_resources.ContextualVersionConflict: (dowhy 0.14 (/miniconda3/envs/cais/lib/python3.10/site-packages), Requirement.parse('dowhy<0.12,>=0.11'), {'causal-agent'})
    Potential fix:
        lock dowhy<=0.11.1
        
     Added build test in CI to check installation of `cais` package.

2. Given the latest Supply Chain Incident in LiteLLM package, it would be better to lock litellm package to >=v1.83.0 or <=v1.82.6 (refer to https://docs.litellm.ai/blog/security-update-march-2026)

3. python: can't open file 'causal-agent/experiments/download_data.py' error
    Fix: update README file (Step 1 — Download the dataset)
    `python experiments/data/download_data.py`
    
4. Docs build failure: sphinx-sitemap not found
